### PR TITLE
Properly fix sqrtf constants

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1089,7 +1089,7 @@ config.libs = [
         "m435Dll",  # Darts of Doom
         objects={
             Object(NonMatching, "REL/m435Dll/main.c"),
-            Object(Matching, "REL/m435Dll/sequence.c"),
+            Object(NonMatching, "REL/m435Dll/sequence.c"),
         },
     ),
     Rel(
@@ -1103,7 +1103,7 @@ config.libs = [
         "m437Dll",  # Balloon of Doom
         objects={
             Object(NonMatching, "REL/m437Dll/main.c"),
-            Object(Matching, "REL/m437Dll/sequence.c"),
+            Object(NonMatching, "REL/m437Dll/sequence.c"),
         },
     ),
     Rel(
@@ -1230,7 +1230,7 @@ config.libs = [
         "m456Dll",  # Take a Breather
         objects={
             Object(NonMatching, "REL/m456Dll/main.c"),
-            Object(Matching, "REL/m456Dll/stage.c"),
+            Object(NonMatching, "REL/m456Dll/stage.c"),
         },
     ),
     Rel(

--- a/include/math.h
+++ b/include/math.h
@@ -10,17 +10,19 @@
 #ifdef __MWERKS__
 extern inline float sqrtf(float x)
 {
-	volatile float y;
-	if(x > 0.0f)
-	{
-		double guess = __frsqrte((double)x);   // returns an approximation to
-		guess = 0.5*guess*(3.0 - guess*guess*x);  // now have 12 sig bits
-		guess = 0.5*guess*(3.0 - guess*guess*x);  // now have 24 sig bits
-		guess = 0.5*guess*(3.0 - guess*guess*x);  // now have 32 sig bits
-		y=(float)(x*guess);
-		return y;
-	}
-	return x;
+    static const double _half = .5;
+    static const double _three = 3.0;
+    volatile float y;
+    if (x > 0.0f)
+    {
+        double guess = __frsqrte((double)x);   // returns an approximation to
+        guess = _half*guess*(_three - guess*guess*x);  // now have 12 sig bits
+        guess = _half*guess*(_three - guess*guess*x);  // now have 24 sig bits
+        guess = _half*guess*(_three - guess*guess*x);  // now have 32 sig bits
+        y = (float)(x*guess);
+        return y ;
+    }
+    return x;
 }
 #else
 float sqrtf(float x);

--- a/include/rel_sqrt_consts.h
+++ b/include/rel_sqrt_consts.h
@@ -1,8 +1,5 @@
 #ifndef _REL_SQRT_CONSTS
 #define _REL_SQRT_CONSTS
 
-const double __fakeHalf = 0.5;
-const double __fakeThree = 3.0;
-
 
 #endif

--- a/src/REL/_minigameDLL/_minigameDLL.c
+++ b/src/REL/_minigameDLL/_minigameDLL.c
@@ -1,6 +1,6 @@
 #include "REL/executor.h"
 #include "dolphin/os.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 void ObjectSetup(void) {
     OSReport("minigame dll setup\n");

--- a/src/REL/board_executor.c
+++ b/src/REL/board_executor.c
@@ -1,5 +1,5 @@
 #include "REL/board_executor.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 static void ObjectSetup(void) {
     BoardObjectSetup(BoardCreate, BoardDestroy);

--- a/src/REL/bootDll/main.c
+++ b/src/REL/bootDll/main.c
@@ -15,7 +15,6 @@
 #include "game/wipe.h"
 #include "math.h"
 
-#include "rel_sqrt_consts.h"
 
 #include "data_num/title.h"
 

--- a/src/REL/m437Dll/main.c
+++ b/src/REL/m437Dll/main.c
@@ -16,7 +16,7 @@
 #include "game/wipe.h"
 
 #include "dolphin.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 #include "string.h"
 
 typedef struct {

--- a/src/REL/m446Dll/main.c
+++ b/src/REL/m446Dll/main.c
@@ -1,5 +1,5 @@
 #include "REL/m446Dll.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 #include "game/audio.h"
 #include "game/frand.h"

--- a/src/REL/m447dll/main.c
+++ b/src/REL/m447dll/main.c
@@ -11,7 +11,7 @@
 #include "game/window.h"
 #include "game/wipe.h"
 
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 typedef struct {
     /* 0x00 */ s16 unk00;

--- a/src/REL/modeltestDll/main.c
+++ b/src/REL/modeltestDll/main.c
@@ -14,6 +14,7 @@
 #include "math.h"
 
 #include "REL/modeltestDll.h"
+#include "math.h"
 
 // -------------------------------------------------------------------------- //
 
@@ -28,8 +29,6 @@ s32 lbl_1_data_0[8] = {
     DATA_MAKE_NUM(DATADIR_MARIOMOT, 0x04),
 };
 
-const f64 unk_rodata_0 = 0.5;
-const f64 unk_rodata_8 = 3.0;
 omObjData *lbl_1_bss_9A4;
 omObjData *lbl_1_bss_9A0;
 

--- a/src/REL/mstory4Dll/main.c
+++ b/src/REL/mstory4Dll/main.c
@@ -8,7 +8,7 @@
 #include "game/gamework_data.h"
 #include "game/flag.h"
 #include "game/chrman.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 #include "REL/executor.h"
 #include "game/board/main.h"
 

--- a/src/REL/option/scene.c
+++ b/src/REL/option/scene.c
@@ -12,7 +12,7 @@
 #include "game/sprite.h"
 #include "game/wipe.h"
 
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 typedef struct {
     /* 0x00 */ s16 id;

--- a/src/REL/present/init.c
+++ b/src/REL/present/init.c
@@ -5,7 +5,7 @@
 #include "game/pad.h"
 #include "game/process.h"
 #include "game/wipe.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 #include "REL/present.h"
 

--- a/src/REL/safDll/main.c
+++ b/src/REL/safDll/main.c
@@ -3,7 +3,7 @@
 #include "game/gamework_data.h"
 #include "game/printfunc.h"
 #include "game/pad.h"
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 s32 lbl_1_data_0 = 100;
 s32 lbl_1_bss_0[192];

--- a/src/REL/selmenuDll/main.c
+++ b/src/REL/selmenuDll/main.c
@@ -14,8 +14,8 @@
 #include "game/pad.h"
 #include "game/printfunc.h"
 #include "game/wipe.h"
+#include "math.h"
 
-#include "rel_sqrt_consts.h"
 
 // MSM Definitions
 static s8 *msmSeGetIndexPtr(s16 datano);

--- a/src/REL/staffDll/main.c
+++ b/src/REL/staffDll/main.c
@@ -9,7 +9,7 @@
 #include "game/window.h"
 #include "game/wipe.h"
 
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 typedef struct StaffData {
     /* 0x00 */ u32 unk_00;

--- a/src/REL/subchrselDll/main.c
+++ b/src/REL/subchrselDll/main.c
@@ -5,7 +5,7 @@
 #include "game/pad.h"
 #include "game/wipe.h"
 
-#include "rel_sqrt_consts.h"
+#include "math.h"
 
 static void SubchrMain(void);
 


### PR DESCRIPTION
Downgrades m435, m437, and m456 TUs to nonmatching. Will affect objdiff relocations.