### PR TITLE
MSL: matched printf.c (US)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -696,7 +696,7 @@ config.libs = [
             Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/mem.c"),
             Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/mem_funcs.c"),
             Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/misc_io.c"),
-            Object(NonMatching, "MSL_C.PPCEABI.bare.H/printf.c"),
+            Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/printf.c"),
             Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/float.c"),
             Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/signal.c"),
             Object(MatchingFor("GMPE01_00", "GMPE01_01"), "MSL_C.PPCEABI.bare.H/string.c"),


### PR DESCRIPTION
The function `double2hex` was mostly copied from the Xenoblade decompilation project ([Xenoblade](https://github.com/xbret/xenoblade)), but heavy changes were required to get a match.